### PR TITLE
Add an option to output environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - run: go test -coverpkg ./... -coverprofile coverage.txt ./...
+      - uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We can discover test cases significantly faster by essentially `grep`-ing for pa
 
 * A test can potentially be executed more than once if another package shares a test with the same name.
   Renaming your tests to be globally unique is currently the best workaround if you want to guarantee a single execution per test function.
-  You can discover test with name collisions by running `shard --total 1 --index 0`.
+  You can discover tests with name collisions by running `shard --total 1 --index 0`.
 * Benchmarks aren't currently collected so running with `-bench` will not have any effect.
       
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/blampe/shard
 
-go 1.22.6
+go 1.21.0

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestProg(t *testing.T) {
+	tests := []struct {
+		p       prog
+		name    string
+		want    string
+		wantErr error
+	}{
+		{
+			name: "default output",
+			p:    prog{total: 1, root: "."},
+			want: `-run ^(?:TestAssign|TestCollect|TestProg)\$  ./. ./internal`,
+		},
+		{
+			name: "env output",
+			p:    prog{output: "env", total: 1, root: "."},
+			want: `SHARD_TESTS=^(?:TestAssign|TestCollect|TestProg)\$
+SHARD_PATHS=./. ./internal`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := tt.p.run()
+			if out != tt.want {
+				t.Errorf("wanted %q but got %q", tt.want, out)
+
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("wanted %q but got %q", tt.wantErr, err)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Adds an `--output env` option to emit `SHARD_TESTS` and `SHARD_PATHS` environment variables.

Example GitHub usage:

```
go run github.com/blampe/shard@latest --total $(TOTAL) --index $(INDEX) --output env >> "$GITHUB_ENV"
```

```
go test -run "$(SHARD_TESTS)" $(SHARD_PATHS)
```